### PR TITLE
On server.js, I specifically allowed requests for the Github Pages domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 
 # Environment variables
 .env
+.env.production
 
 # Runtime data
 pids

--- a/email_backend/server.js
+++ b/email_backend/server.js
@@ -6,7 +6,7 @@ require('dotenv').config();                                                     
 const app = express();                  
 const PORT = process.env.PORT || 5000;                                          //Port the server will listen on. Else, it will default to 5000 (when it runs locally for instance)
             
-app.use(cors());                                                                //Allows for requests from different domains (in this case the frontend Github Pages)       
+app.use(cors({origin: 'https://masterpancho.github.io'}));                      //Allows for requests from Github Pages domain            
 app.use(express.json());                                                        //Middleware to parse incoming data raquests with JSON payloads (user info). Use req.body to handle this data
             
 //POST route at /send-email to handle sending email requests            
@@ -52,5 +52,5 @@ app.post('/send-email', async (req, res) => {                                   
 
 //Starts server on the specified PORT 
 app.listen(PORT, () => {
-    console.log(`Server is running on http://localhost:${PORT}`);
+    console.log(`Server is running on this host: http://localhost:${PORT}`);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-router-dom": "^7.1.0",
         "react-tilt": "^1.0.2",
         "react-vertical-timeline-component": "^3.5.3",
-        "three": "^0.171.0"
+        "three": "^0.171.0",
+        "three-stdlib": "^2.35.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-router-dom": "^7.1.0",
     "react-tilt": "^1.0.2",
     "react-vertical-timeline-component": "^3.5.3",
-    "three": "^0.171.0"
+    "three": "^0.171.0",
+    "three-stdlib": "^2.35.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",


### PR DESCRIPTION
On server.js, I specifically configured the backend to allow requests only from the GitHub Pages domain by editing the CORS middleware. This restricts access to the backend, ensuring that only requests originating from my GitHub Pages frontend are allowed.

